### PR TITLE
Remove double loading of homepage bug and add loading wallet icon

### DIFF
--- a/src/js/controllers/tab-home.js
+++ b/src/js/controllers/tab-home.js
@@ -16,6 +16,7 @@ angular.module('copayApp.controllers').controller('tabHomeController',
     $scope.isWindowsPhoneApp = platformInfo.isCordova && platformInfo.isWP;
     $scope.isNW = platformInfo.isNW;
     $scope.showRateCard = {};
+    $scope.loadingWallets = true;
 
     $scope.$on("$ionicView.afterEnter", function() {
       startupService.ready();
@@ -84,6 +85,11 @@ angular.module('copayApp.controllers').controller('tabHomeController',
       });
 
       listeners = [
+        $rootScope.$on('profileBound', function(e, walletId, type, n) {
+          updateAllWallets();
+          $scope.loadingWallets = false;
+          if ($scope.recentTransactionsEnabled) getNotifications();
+        }),
         $rootScope.$on('bwsEvent', function(e, walletId, type, n) {
           var wallet = profileService.getWallet(walletId);
           updateWallet(wallet);
@@ -123,6 +129,12 @@ angular.module('copayApp.controllers').controller('tabHomeController',
           $scope.$apply();
         }, 10);
       });
+
+      $timeout(function() {
+        // If  haven't loaded wallets in 2.5s. Show create wallet.
+        // Handles issues when no wallets exist and you are navigating the app
+        $scope.loadingWallets = false;
+      }, 2500);
     });
 
     $scope.$on("$ionicView.leave", function(event, data) {
@@ -231,6 +243,7 @@ angular.module('copayApp.controllers').controller('tabHomeController',
           }
         });
       });
+      $scope.loadingWallets = false;
     };
 
     var updateWallet = function(wallet) {

--- a/src/js/routes.js
+++ b/src/js/routes.js
@@ -273,6 +273,7 @@ angular.module('copayApp').config(function(historicLogProvider, $provide, $logPr
         templateUrl: 'views/tabs.html'
       })
       .state('tabs.home', {
+        cache: false,
         url: '/home/:fromOnboarding',
         views: {
           'tab-home': {
@@ -1301,36 +1302,32 @@ angular.module('copayApp').config(function(historicLogProvider, $provide, $logPr
           profileService.storeProfileIfDirty();
           $log.debug('Profile loaded ... Starting UX.');
           scannerService.gentleInitialize();
-          // Reload tab-home if necessary (from root path: starting)
-          $state.go('starting', {}, {
-            'reload': true,
-            'notify': $state.current.name == 'starting' ? false : true
-          }).then(function() {
           $ionicHistory.nextViewOptions({
-              disableAnimate: true,
-              historyRoot: true
+            disableAnimate: true,
+            historyRoot: true
+          });
+          if (navigator.onLine === false) {
+            $log.debug('We are now offline. Changing to route "offline"')
+            $state.transitionTo('offline').then(function() {
+              // Clear history
+              $ionicHistory.clearHistory();
             });
-            if (navigator.onLine === false) {
-              $log.debug('We are now offline. Changing to route "offline"')
-              $state.transitionTo('offline').then(function() {
-                // Clear history
-                $ionicHistory.clearHistory();
-              });
-            } else {
+          } else {
+            if ($state.current.name !== 'tabs.home') {
               $state.transitionTo('tabs.home').then(function() {
                 // Clear history
                 $ionicHistory.clearHistory();
               });
             }
+          }
 
-            applicationService.appLockModal('check');
-          });
-        };
-        // After everything have been loaded
-        $timeout(function() {
-          emailService.init(); // Update email subscription if necessary
-          openURLService.init();
-        }, 1000);
+          applicationService.appLockModal('check');
+          // After everything have been loaded
+          $timeout(function() {
+            emailService.init(); // Update email subscription if necessary
+            openURLService.init();
+          }, 1000);
+        }
       });
     });
 

--- a/src/js/services/profileService.js
+++ b/src/js/services/profileService.js
@@ -281,6 +281,8 @@ angular.module('copayApp.services')
           });
         });
       });
+
+      $rootScope.$emit('profileBound');
     };
 
     root._queue = [];

--- a/src/sass/views/tab-home.scss
+++ b/src/sass/views/tab-home.scss
@@ -3,6 +3,9 @@
   .icon-create-wallet {
     background-color: #4A90E2; // default wallet color
   }
+  .icon-loading-wallet {
+    background-color: #A2A6A6; // default wallet color
+  }
   .icon-buy-bitcoin {
     background-image: $v-bitcoin-icon;
     background-color: $v-bitcoin-orange;

--- a/www/views/tab-home.html
+++ b/www/views/tab-home.html
@@ -76,7 +76,14 @@
         <a ui-sref="tabs.add" ng-if="wallets[0]"><i class="icon ion-ios-plus-empty list-add-button"></i></a>
       </div>
       <div>
-        <a ng-if="!wallets[0]" ui-sref="tabs.add" class="item item-icon-left item-big-icon-left item-icon-right next-step">
+        <span ng-if="loadingWallets" class="item item-icon-left item-big-icon-left item-icon-right next-step">
+          <i class="icon big-icon-svg">
+            <img src="img/icon-wallet.svg" class="bg wallet icon-loading-wallet"/>
+          </i>
+          <span translate>Loading wallets...</span>
+          <i class="icon bp-arrow-right"></i>
+        </span>
+        <a ng-if="!wallets[0] && !loadingWallets" ui-sref="tabs.add" class="item item-icon-left item-big-icon-left item-icon-right next-step">
          <i class="icon big-icon-svg">
            <img src="img/icon-wallet.svg" class="bg wallet icon-create-wallet"/>
          </i>


### PR DESCRIPTION
This PR removes an issue where the home page would load multiple time and multiple logins would occur.

This was occurring because the page would load once, before data was retrieve, and then it would reload the page to show the wallets.

To solve this, instead we show a 'loading...' wallet screen and then fire an event once a wallet is loaded.
We also timeout after 2.5s and assume there is no wallet to load. 

## Testing required
- [x] Code review 
- [x] Optional regression to ensure the wallets show up when loaded