### PR TITLE
Additional setup steps

### DIFF
--- a/src/js/controllers/create.js
+++ b/src/js/controllers/create.js
@@ -218,7 +218,9 @@ angular.module('copayApp.controllers').controller('createController',
                 walletId: client.credentials.walletId
               });
             }, 100);
-          } else $state.go('tabs.home');
+          } else {
+            $state.go('onboarding.backupRequest', { walletId: client.credentials.walletId });
+          }
         });
       }, 300);
     }

--- a/src/js/controllers/create.js
+++ b/src/js/controllers/create.js
@@ -1,7 +1,7 @@
 'use strict';
 
 angular.module('copayApp.controllers').controller('createController',
-  function($scope, $rootScope, $timeout, $log, lodash, $state, $ionicScrollDelegate, $ionicHistory, profileService, configService, gettextCatalog, ledger, trezor, intelTEE, derivationPathHelper, ongoingProcess, walletService, storageService, popupService, appConfigService, pushNotificationsService) {
+  function ($scope, $rootScope, $timeout, $log, lodash, $state, $ionicScrollDelegate, $ionicHistory, profileService, configService, gettextCatalog, ledger, trezor, intelTEE, derivationPathHelper, ongoingProcess, walletService, storageService, popupService, appConfigService, pushNotificationsService) {
 
     /* For compressed keys, m*73 + n*34 <= 496 */
     var COPAYER_PAIR_LIMITS = {
@@ -19,7 +19,7 @@ angular.module('copayApp.controllers').controller('createController',
       12: 1,
     };
 
-    $scope.$on("$ionicView.beforeEnter", function(event, data) {
+    $scope.$on("$ionicView.beforeEnter", function (event, data) {
       $scope.formData = {};
       var defaults = configService.getDefaults();
       var tc = $state.current.name == 'tabs.add.create-personal' ? 1 : defaults.wallet.totalCopayers;
@@ -29,41 +29,17 @@ angular.module('copayApp.controllers').controller('createController',
       $scope.formData.derivationPath = derivationPathHelper.default;
       $scope.setTotalCopayers(tc);
       updateRCSelect(tc);
-      resetPasswordFields();
     });
 
-    $scope.showAdvChange = function() {
+    $scope.showAdvChange = function () {
       $scope.showAdv = !$scope.showAdv;
-      $scope.encrypt = null;
       $scope.resizeView();
     };
 
-    $scope.checkPassword = function(pw1, pw2) {
-      if (pw1 && pw1.length > 0) {
-        if (pw2 && pw2.length > 0) {
-          if (pw1 == pw2) $scope.result = 'correct';
-          else {
-            $scope.formData.passwordSaved = null;
-            $scope.result = 'incorrect';
-          }
-        } else
-          $scope.result = null;
-      } else
-        $scope.result = null;
-    };
-
-    $scope.resizeView = function() {
-      $timeout(function() {
+    $scope.resizeView = function () {
+      $timeout(function () {
         $ionicScrollDelegate.resize();
       }, 10);
-      resetPasswordFields();
-    };
-
-    function resetPasswordFields() {
-      $scope.formData.passphrase = $scope.formData.createPassphrase = $scope.formData.passwordSaved = $scope.formData.repeatPassword = $scope.result = null;
-      $timeout(function() {
-        $scope.$apply();
-      });
     };
 
     function updateRCSelect(n) {
@@ -120,13 +96,13 @@ angular.module('copayApp.controllers').controller('createController',
       $scope.seedOptions = seedOptions;
     };
 
-    $scope.setTotalCopayers = function(tc) {
+    $scope.setTotalCopayers = function (tc) {
       $scope.formData.totalCopayers = tc;
       updateRCSelect(tc);
       updateSeedSourceSelect(tc);
     };
 
-    $scope.create = function() {
+    $scope.create = function () {
 
       var opts = {
         name: $scope.formData.walletName,
@@ -198,7 +174,7 @@ angular.module('copayApp.controllers').controller('createController',
             return;
         }
 
-        src.getInfoForNewWallet(opts.n > 1, account, opts.networkName, function(err, lopts) {
+        src.getInfoForNewWallet(opts.n > 1, account, opts.networkName, function (err, lopts) {
           ongoingProcess.set('connecting ' + $scope.formData.seedSource.id, false);
           if (err) {
             popupService.showAlert(gettextCatalog.getString('Error'), err);
@@ -214,8 +190,8 @@ angular.module('copayApp.controllers').controller('createController',
 
     function _create(opts) {
       ongoingProcess.set('creatingWallet', true);
-      $timeout(function() {
-        profileService.createWallet(opts, function(err, client) {
+      $timeout(function () {
+        profileService.createWallet(opts, function (err, client) {
           ongoingProcess.set('creatingWallet', false);
           if (err) {
             $log.warn(err);
@@ -237,7 +213,7 @@ angular.module('copayApp.controllers').controller('createController',
               disableAnimate: true
             });
             $state.go('tabs.home');
-            $timeout(function() {
+            $timeout(function () {
               $state.transitionTo('tabs.copayers', {
                 walletId: client.credentials.walletId
               });

--- a/src/js/controllers/join.js
+++ b/src/js/controllers/join.js
@@ -1,26 +1,24 @@
 'use strict';
 
 angular.module('copayApp.controllers').controller('joinController',
-  function($scope, $rootScope, $timeout, $state, $ionicHistory, $ionicScrollDelegate, profileService, configService, storageService, applicationService, gettextCatalog, lodash, ledger, trezor, intelTEE, derivationPathHelper, ongoingProcess, walletService, $log, $stateParams, popupService, appConfigService) {
-
-    console.log('navigator', navigator);
+  function ($scope, $rootScope, $timeout, $state, $ionicHistory, $ionicScrollDelegate, profileService, configService, storageService, applicationService, gettextCatalog, lodash, ledger, trezor, intelTEE, derivationPathHelper, ongoingProcess, walletService, $log, $stateParams, popupService, appConfigService) {
 
     navigator.getUserMedia = navigator.getUserMedia || navigator.webkitGetUserMedia || navigator.mozGetUserMedia || navigator.msGetUserMedia;
 
-    console.log('navigator.getUserMedia', navigator.getUserMedia);
-
-    $scope.$on("$ionicView.beforeEnter", function(event, data) {
+    $scope.$on("$ionicView.beforeEnter", function (event, data) {
       var defaults = configService.getDefaults();
+      var config = configService.getSync();
       $scope.formData = {};
       $scope.formData.bwsurl = defaults.bws.url;
       $scope.formData.derivationPath = derivationPathHelper.default;
       $scope.formData.account = 1;
       $scope.formData.secret = null;
+      $scope.formData.coin = data.stateParams.coin;
       resetPasswordFields();
       updateSeedSourceSelect();
     });
 
-    $scope.showAdvChange = function() {
+    $scope.showAdvChange = function () {
       $scope.showAdv = !$scope.showAdv;
       $scope.encrypt = null;
       $scope.resizeView();

--- a/src/js/controllers/onboarding/tour.js
+++ b/src/js/controllers/onboarding/tour.js
@@ -13,44 +13,44 @@ angular.module('copayApp.controllers').controller('tourController',
       spaceBetween: 100
     }
 
-    $scope.$on("$ionicSlides.sliderInitialized", function(event, data) {
+    $scope.$on("$ionicSlides.sliderInitialized", function (event, data) {
       $scope.slider = data.slider;
     });
 
-    $scope.$on("$ionicSlides.slideChangeStart", function(event, data) {
+    $scope.$on("$ionicSlides.slideChangeStart", function (event, data) {
       $scope.data.index = data.slider.activeIndex;
     });
 
-    $scope.$on("$ionicSlides.slideChangeEnd", function(event, data) {});
+    $scope.$on("$ionicSlides.slideChangeEnd", function (event, data) { });
 
-    $scope.$on("$ionicView.enter", function(event, data) {
-      rateService.whenAvailable(function() {
+    $scope.$on("$ionicView.enter", function (event, data) {
+      rateService.whenAvailable(function () {
         var localCurrency = 'USD';
         var btcAmount = 1;
         var rate = rateService.toFiat(btcAmount * 1e8, localCurrency);
         $scope.localCurrencySymbol = '$';
         $scope.localCurrencyPerBtc = $filter('formatFiatAmount')(parseFloat(rate.toFixed(2), 10));
-        $timeout(function() {
+        $timeout(function () {
           $scope.$apply();
         })
       });
     });
 
     var retryCount = 0;
-    $scope.createDefaultWallet = function() {
+    $scope.createDefaultWallet = function () {
       ongoingProcess.set('creatingWallet', true);
-      $timeout(function() {
-        profileService.createDefaultWallet(function(err, walletClient) {
+      $timeout(function () {
+        profileService.createDefaultWallet(function (err, walletClient) {
           if (err) {
             $log.warn(err);
 
-            return $timeout(function() {
+            return $timeout(function () {
               $log.warn('Retrying to create default wallet.....:' + ++retryCount);
               if (retryCount > 3) {
                 ongoingProcess.set('creatingWallet', false);
                 popupService.showAlert(
                   gettextCatalog.getString('Cannot Create Wallet'), err,
-                  function() {
+                  function () {
                     retryCount = 0;
                     return $scope.createDefaultWallet();
                   }, gettextCatalog.getString('Retry'));
@@ -67,16 +67,33 @@ angular.module('copayApp.controllers').controller('tourController',
             walletId: walletId
           });
 
-            /*
-          $state.go('onboarding.backupRequest', {
-            walletId: walletId
-          });
-            */
+          /*
+        $state.go('onboarding.backupRequest', {
+          walletId: walletId
+        });
+          */
         });
       }, 300);
     };
 
-    $scope.goBack = function() {
+    /*
+      $ionicModal.fromTemplateUrl('views/modals/password-warning.html', {
+        scope: $scope
+      }).then(function(modal) {
+        $scope.passwordWarningModal = modal;
+        $scope.passwordWarningModal.show();
+      });
+    /*
+    /*
+      $scope.close = function() {
+      $scope.passwordWarningModal.hide();
+    };
+    $scope.encrypt = function() {
+
+    }
+    */
+
+    $scope.goBack = function () {
       if ($scope.data.index != 0) $scope.slider.slidePrev();
       else $state.go('onboarding.welcome');
     }

--- a/src/js/controllers/tab-home.js
+++ b/src/js/controllers/tab-home.js
@@ -135,6 +135,10 @@ angular.module('copayApp.controllers').controller('tabHomeController',
         // Handles issues when no wallets exist and you are navigating the app
         $scope.loadingWallets = false;
       }, 2500);
+
+      $timeout(function() {
+        $rootScope.$apply();
+      }, 10);
     });
 
     $scope.$on("$ionicView.leave", function(event, data) {
@@ -244,6 +248,9 @@ angular.module('copayApp.controllers').controller('tabHomeController',
         });
       });
       $scope.loadingWallets = false;
+      $timeout(function() {
+        $rootScope.$apply();
+      }, 10);
     };
 
     var updateWallet = function(wallet) {

--- a/src/js/directives/copyToClipboard.js
+++ b/src/js/directives/copyToClipboard.js
@@ -8,6 +8,7 @@ angular.module('copayApp.directives')
         copyToClipboard: '=copyToClipboard'
       },
       link: function(scope, elem, attrs, ctrl) {
+        console.log('ran copy to clipboard')
         var isCordova = platformInfo.isCordova;
         var isChromeApp = platformInfo.isChromeApp;
         var isNW = platformInfo.isNW;
@@ -26,6 +27,8 @@ angular.module('copayApp.directives')
             nodeWebkitService.writeToClipboard(data);
           } else if (clipboard.supported) {
             clipboard.copyText(data);
+          } else if (navigator.clipboard) {
+            navigator.clipboard.writeText(data)
           } else {
             // No supported
             return;

--- a/src/js/services/onGoingProcess.js
+++ b/src/js/services/onGoingProcess.js
@@ -6,6 +6,7 @@ angular.module('copayApp.services').factory('ongoingProcess', function($log, $ti
   var isWindowsPhoneApp = platformInfo.isCordova && platformInfo.isWP;
 
   var ongoingProcess = {};
+  var pausedOngoingProcess = {};
 
   var processNames = {
     'broadcastingTx': gettext('Broadcasting transaction'),
@@ -63,6 +64,18 @@ angular.module('copayApp.services').factory('ongoingProcess', function($log, $ti
   root.get = function(processName) {
     return ongoingProcess[processName];
   };
+
+  root.pause = function() {
+    pausedOngoingProcess = ongoingProcess;
+    root.clear();
+  }
+
+  root.resume = function() {
+    lodash.forEach(pausedOngoingProcess, function(v, k) {
+      root.set(k, v);
+    });
+    pausedOngoingProcess = {};
+  }
 
   root.set = function(processName, isOn, customHandler) {
     $log.debug('ongoingProcess', processName, isOn);

--- a/src/js/services/profileService.js
+++ b/src/js/services/profileService.js
@@ -1,6 +1,6 @@
 'use strict';
 angular.module('copayApp.services')
-  .factory('profileService', function profileServiceFactory($rootScope, $timeout, $filter, $log, sjcl, lodash, storageService, bwcService, configService, gettextCatalog, bwcError, uxLanguage, platformInfo, txFormatService, $state) {
+  .factory('profileService', function profileServiceFactory($rootScope, $timeout, $filter, $log, $state, sjcl, lodash, storageService, bwcService, configService, gettextCatalog, bwcError, uxLanguage, platformInfo, txFormatService, appConfigService, popupService, ongoingProcess) {
 
 
     var isChromeApp = platformInfo.isChromeApp;
@@ -134,7 +134,7 @@ angular.module('copayApp.services')
         wallet.setNotificationsInterval(UPDATE_PERIOD);
         wallet.openWallet(function(err) {
           if (wallet.status !== true)
-            $log.log('Wallet + ' + walletId + ' status:' + wallet.status)
+            $log.debug('Wallet + ' + walletId + ' status:' + wallet.status)
         });
       });
 
@@ -221,7 +221,6 @@ angular.module('copayApp.services')
         var defaults = configService.getDefaults();
         return ((config.bwsFor && config.bwsFor[walletId]) || defaults.bws.url);
       };
-
 
       var client = bwcService.getClient(JSON.stringify(credentials), {
         bwsurl: getBWSURL(credentials.walletId),
@@ -338,7 +337,11 @@ angular.module('copayApp.services')
         }
       } else if (opts.extendedPrivateKey) {
         try {
-          walletClient.seedFromExtendedPrivateKey(opts.extendedPrivateKey);
+          walletClient.seedFromExtendedPrivateKey(opts.extendedPrivateKey, {
+            network: network,
+            account: opts.account || 0,
+            derivationStrategy: opts.derivationStrategy || 'BIP44',
+          });
         } catch (ex) {
           $log.warn(ex);
           return cb(gettextCatalog.getString('Could not create using the specified extended private key'));
@@ -382,7 +385,11 @@ angular.module('copayApp.services')
 
     // Creates a wallet on BWC/BWS
     var doCreateWallet = function(opts, cb) {
-      $log.debug('Creating Wallet:', opts);
+      var showOpts = lodash.clone(opts);
+      if (showOpts.extendedPrivateKey) showOpts.extendedPrivateKey='[hidden]';
+      if (showOpts.mnemonic) showOpts.mnemonic='[hidden]';
+
+      $log.debug('Creating Wallet:', showOpts);
       $timeout(function() {
         seedWallet(opts, function(err, walletClient) {
           if (err) return cb(err);
@@ -489,43 +496,97 @@ angular.module('copayApp.services')
       });
     }
 
+    // An alert dialog
+    var askPassword = function(name, title, cb) {
+      var opts = {
+        inputType: 'password',
+        forceHTMLPrompt: true,
+        class: 'text-warn'
+      };
+      popupService.showPrompt(title, name, opts, function(res) {
+        if (!res) return cb();
+        if (res) return cb(res)
+      });
+    };
+
+    var showWarningNoEncrypt = function(cb) {
+      var title = gettextCatalog.getString('Are you sure?');
+      var msg = gettextCatalog.getString('Your wallet keys will be stored in plan text in this device, if an other app access the store it will be able to access your Bitcoin');
+      var yes = gettextCatalog.getString('Yes');
+      var no = gettextCatalog.getString('No');
+      popupService.showConfirm(title, msg, yes, no, function(res) {
+        return cb(res);
+      });
+    };
+
+    var encryptWallet = function(wallet, cb) {
+
+      var title = gettextCatalog.getString('Please enter a password to encrypt your wallet keys on this device storage');
+      var warnMsg = gettextCatalog.getString('Your wallet key will be encrypted. The Spending Password cannot be recovered. Be sure to write it down.');
+      askPassword(warnMsg, title, function(password) {
+        if (!password) {
+          showWarningNoEncrypt(function(res) {
+            if (res) return cb()
+            return encryptWallet(wallet, cb);
+          });
+        } else {
+          title = gettextCatalog.getString('Confirm your new spending password');
+          askPassword(warnMsg, title, function(password2) {
+            if (!password2 || password != password2)
+              return encryptWallet(wallet, cb);
+
+            wallet.encryptPrivateKey(password);
+            return cb();
+          });
+        }
+      });
+    };
+
     // Adds and bind a new client to the profile
     var addAndBindWalletClient = function(client, opts, cb) {
       if (!client || !client.credentials)
         return cb(gettextCatalog.getString('Could not access wallet'));
 
-      var walletId = client.credentials.walletId
+      // Encrypt wallet
+      ongoingProcess.pause();
+      encryptWallet(client, function() {
+        ongoingProcess.resume();
 
-      if (!root.profile.addWallet(JSON.parse(client.export())))
-        return cb(gettextCatalog.getString('Wallet already in Copay'));
+        var walletId = client.credentials.walletId
+
+        if (!root.profile.addWallet(JSON.parse(client.export())))
+          return cb(gettextCatalog.getString("Wallet already in {{appName}}", {
+            appName: appConfigService.nameCase
+          }));
 
 
-      var skipKeyValidation = shouldSkipValidation(walletId);
-      if (!skipKeyValidation)
-        root.runValidation(client);
+        var skipKeyValidation = shouldSkipValidation(walletId);
+        if (!skipKeyValidation)
+          root.runValidation(client);
 
-      root.bindWalletClient(client);
+        root.bindWalletClient(client);
 
-      var saveBwsUrl = function(cb) {
-        var defaults = configService.getDefaults();
-        var bwsFor = {};
-        bwsFor[walletId] = opts.bwsurl || defaults.bws.url;
+        var saveBwsUrl = function(cb) {
+          var defaults = configService.getDefaults();
+          var bwsFor = {};
+          bwsFor[walletId] = opts.bwsurl || defaults.bws.url;
 
-        // Dont save the default
-        if (bwsFor[walletId] == defaults.bws.url)
-          return cb();
+          // Dont save the default
+          if (bwsFor[walletId] == defaults.bws.url)
+            return cb();
 
-        configService.set({
-          bwsFor: bwsFor,
-        }, function(err) {
-          if (err) $log.warn(err);
-          return cb();
-        });
-      };
+          configService.set({
+            bwsFor: bwsFor,
+          }, function(err) {
+            if (err) $log.warn(err);
+            return cb();
+          });
+        };
 
-      saveBwsUrl(function() {
-        storageService.storeProfile(root.profile, function(err) {
-          return cb(err, client);
+        saveBwsUrl(function() {
+          storageService.storeProfile(root.profile, function(err) {
+            return cb(err, client);
+          });
         });
       });
     };
@@ -769,12 +830,14 @@ angular.module('copayApp.services')
 
       if (opts.hasFunds) {
         ret = lodash.filter(ret, function(w) {
+          if (!w.status) return;
           return (w.status.availableBalanceSat > 0);
         });
       }
 
       if (opts.minAmount) {
         ret = lodash.filter(ret, function(w) {
+          if (!w.status) return;
           return (w.status.availableBalanceSat > opts.minAmount);
         });
       }

--- a/src/js/services/profileService.js
+++ b/src/js/services/profileService.js
@@ -511,9 +511,9 @@ angular.module('copayApp.services')
 
     var showWarningNoEncrypt = function(cb) {
       var title = gettextCatalog.getString('Are you sure?');
-      var msg = gettextCatalog.getString('Your wallet keys will be stored in plan text in this device, if an other app access the store it will be able to access your Bitcoin');
-      var yes = gettextCatalog.getString('Yes');
-      var no = gettextCatalog.getString('No');
+      var msg = gettextCatalog.getString('Your wallet keys will be stored in plain text and you will be vulnerable to having you coins stolen. We highly recommend pressing no and choosing a password.');
+      var yes = gettextCatalog.getString('No password');
+      var no = gettextCatalog.getString('Create password');
       popupService.showConfirm(title, msg, yes, no, function(res) {
         return cb(res);
       });
@@ -521,8 +521,8 @@ angular.module('copayApp.services')
 
     var encryptWallet = function(wallet, cb) {
 
-      var title = gettextCatalog.getString('Please enter a password to encrypt your wallet keys on this device storage');
-      var warnMsg = gettextCatalog.getString('Your wallet key will be encrypted. The Spending Password cannot be recovered. Be sure to write it down.');
+      var title = gettextCatalog.getString('Please enter a password to encrypt your wallet');
+      var warnMsg = gettextCatalog.getString('This password can never be recovered or reset!');
       askPassword(warnMsg, title, function(password) {
         if (!password) {
           showWarningNoEncrypt(function(res) {

--- a/src/js/services/profileService.js
+++ b/src/js/services/profileService.js
@@ -65,6 +65,15 @@ angular.module('copayApp.services')
       });
     };
 
+    function _needsEncryption(wallet, cb) {
+      if (!wallet || !wallet.credentials) { return cb(false); }
+      if (wallet.credentials.network === 'testnet') { return cb(false); }
+      if (wallet.credentials.mnemonicEncrypted) { return cb(false); }
+      if (wallet.credentials.xPrivKeyEncrypted) { return cb(false); }
+      // not encrypted
+      return cb(true);
+    };
+
     function _balanceIsHidden(wallet, cb) {
       storageService.getHideBalanceFlag(wallet.credentials.walletId, function(err, shouldHideBalance) {
         if (err) $log.error(err);
@@ -95,6 +104,10 @@ angular.module('copayApp.services')
 
       _needsBackup(wallet, function(val) {
         wallet.needsBackup = val;
+      });
+
+      _needsEncryption(wallet, function(val) {
+        wallet.needsEncryption = val;
       });
 
       _balanceIsHidden(wallet, function(val) {

--- a/src/js/services/walletService.js
+++ b/src/js/services/walletService.js
@@ -2,8 +2,8 @@
 
 angular.module('copayApp.services').factory('walletService', function($log, $timeout, lodash, trezor, ledger, intelTEE, storageService, configService, rateService, uxLanguage, $filter, gettextCatalog, bwcError, $ionicPopup, fingerprintService, ongoingProcess, gettext, $rootScope, txFormatService, $ionicModal, $state, bwcService, bitcore, popupService) {
 
-  // Ratio low amount warning (fee/amount) in incoming TX 
-  var LOW_AMOUNT_RATIO = 0.15; 
+  // Ratio low amount warning (fee/amount) in incoming TX
+  var LOW_AMOUNT_RATIO = 0.15;
 
   // Ratio of "many utxos" warning in total balance (fee/amount)
   var TOTAL_LOW_WARNING_RATIO = .3;
@@ -922,7 +922,7 @@ angular.module('copayApp.services').factory('walletService', function($log, $tim
   };
 
 
-  // Approx utxo amount, from which the uxto is economically redeemable  
+  // Approx utxo amount, from which the uxto is economically redeemable
   root.getMinFee = function(wallet, feeLevels, nbOutputs) {
     var lowLevelRate = (lodash.find(feeLevels[wallet.network], {
       level: 'normal',
@@ -933,7 +933,7 @@ angular.module('copayApp.services').factory('walletService', function($log, $tim
   };
 
 
-  // Approx utxo amount, from which the uxto is economically redeemable  
+  // Approx utxo amount, from which the uxto is economically redeemable
   root.getLowAmount = function(wallet, feeLevels, nbOutputs) {
     var minFee = root.getMinFee(wallet,feeLevels, nbOutputs);
     return parseInt( minFee / LOW_AMOUNT_RATIO);

--- a/src/sass/views/onboarding/onboard-backup-request.scss
+++ b/src/sass/views/onboarding/onboard-backup-request.scss
@@ -1,6 +1,6 @@
 #onboarding-backup-request {
   #warning {
-    padding-top: 15%;
+    padding-top: 20px;
     display: block;
     flex-direction: column;
     height: calc(100vh - 320px);

--- a/src/sass/views/wallet-backup-phrase.scss
+++ b/src/sass/views/wallet-backup-phrase.scss
@@ -151,6 +151,7 @@
   }
   .cta-buttons {
     @extend %cta-buttons;
+    position: relative !important;
     padding-bottom: 5vh;
     @media(max-height: 480px) {
       padding-bottom: 3vh;

--- a/www/views/backup.html
+++ b/www/views/backup.html
@@ -21,6 +21,11 @@
           <span class="backup-phrase-content-word-readonly" ng-repeat="word in mnemonicWords track by $index"><span style="white-space:nowrap">{{word}}</span><span ng-show="useIdeograms">&#x3000;</span> </span>
         </div>
       </div>
+      <div>
+        <button copy-to-clipboard="copyRecoveryPhrase()">Copy to clipboard</button>
+        <button ng-click="generateQrCode()">show QR code</button>
+        <div ng-include="'views/tab-export-qrCode.html'" ng-if="formData.supported"></div>
+      </div>
       <div class="password-required" ng-show="mnemonicHasPassphrase" translate>
         This recovery phrase was created with a password. To recover this wallet both the recovery phrase and password are needed.
       </div>

--- a/www/views/join.html
+++ b/www/views/join.html
@@ -14,11 +14,7 @@
 
         <label class="item item-input item-stacked-label no-border">
           <span class="input-label" translate>Your nickname</span>
-          <input type="text"
-          placeholder="Satoshi"
-          name="myName"
-          ng-model="formData.myName"
-          required>
+          <input type="text" placeholder="Satoshi" name="myName" ng-model="formData.myName" required>
         </label>
 
         <div>
@@ -28,12 +24,8 @@
               <i ng-show="!setupForm.secret.$invalid" class="icon ion-checkmark-circled valid"></i>
               <i ng-show="setupForm.secret.$invalid && formData.secret" class="icon ion-close-circled invalid"></i>
             </div>
-            <input id="secret"
-                   type="text"
-                   placeholder="{{'Paste invitation here'|translate}}"
-                   name="secret"
-                   ng-model="formData.secret"
-                   wallet-secret required>
+            <input id="secret" type="text" placeholder="{{'Paste invitation here'|translate}}" name="secret" ng-model="formData.secret"
+              wallet-secret required>
           </label>
           <div class="qr-scan-icon">
             <qr-scanner class="qr-icon size-24" on-scan="onQrCodeScannedJoin(data)"></qr-scanner>
@@ -57,97 +49,32 @@
             <div class="input-label" translate>
               Wallet Key
             </div>
-            <select class="m10t"
-                    ng-model="formData.seedSource"
-                    ng-options="seed as seed.label for seed in seedOptions"
-                    ng-change="resizeView()">
+            <select class="m10t" ng-model="formData.seedSource" ng-options="seed as seed.label for seed in seedOptions" ng-change="resizeView()">
             </select>
           </label>
 
-          <label class="item item-input item-stacked-label"
-                 ng-show="formData.seedSource.id == 'trezor' || formData.seedSource.id == 'ledger'">
+          <label class="item item-input item-stacked-label" ng-show="formData.seedSource.id == 'trezor' || formData.seedSource.id == 'ledger'">
             <span class="input-label" translate>Account Number</span>
             <input type="number" id="account" ng-model="formData.account" ignore-mouse-wheel>
           </label>
 
           <label class="item item-input item-stacked-label" ng-show="formData.seedSource.id == 'set'">
             <span class="input-label" translate>Wallet Recovery Phrase</span>
-            <input id="ext-master"
-                   placeholder="{{'Enter the recovery phrase (BIP39)'|translate}}"
-                   autocapitalize="off"
-                   type="text"
-                   name="privateKey"
-                   ng-model="formData.privateKey">
+            <input id="ext-master" placeholder="{{'Enter the recovery phrase (BIP39)'|translate}}" autocapitalize="off" type="text" name="privateKey"
+              ng-model="formData.privateKey">
           </label>
-
-          <ion-toggle class="has-comment" ng-model="encrypt" toggle-class="toggle-positive" ng-change="resizeView()" ng-show="formData.seedSource.id == 'new' || formData.seedSource.id == 'set'">
-            <span class="toggle-label" translate>Add a password</span>
-          </ion-toggle>
-          <div class="comment">
-            <span ng-show="formData.seedSource.id == 'new'" translate>Add an optional password to secure the recovery phrase</span>
-            <span ng-show="formData.seedSource.id == 'set'" translate>The recovery phrase could require a password to be imported</span>
-          </div>
-
-          <div class="item item-input" ng-show="encrypt">
-            <input ng-show="formData.seedSource.id == 'new'"
-                   placeholder="{{'Password'|translate}}"
-                   type="password"
-                   autocapitalize="off"
-                   name="createPassphrase"
-                   ng-model="formData.createPassphrase"
-                   ng-change="checkPassword(formData.createPassphrase, formData.repeatPassword)"
-                   ng-class="{'correct': result == 'correct', 'incorrect': result == 'incorrect'}">
-
-            <input ng-show="formData.seedSource.id == 'set'"
-                   placeholder="{{'Password'|translate}}"
-                   type="password"
-                   autocapitalize="off"
-                   name="passphrase"
-                   ng-model="formData.passphrase"
-                   ng-change="checkPassword(formData.passphrase, formData.repeatPassword)"
-                   ng-class="{'correct': result == 'correct', 'incorrect': result == 'incorrect'}">
-          </div>
-
-          <div class="item item-input" ng-show="encrypt">
-            <input ng-show="formData.seedSource.id == 'new'"
-                   placeholder="{{'Repeat password'|translate}}"
-                   type="password"
-                   autocapitalize="off"
-                   ng-model="formData.repeatPassword"
-                   ng-change="checkPassword(formData.createPassphrase, formData.repeatPassword)"
-                   ng-class="{'correct': result == 'correct', 'incorrect': result == 'incorrect'}">
-
-             <input ng-show="formData.seedSource.id == 'set'"
-                    placeholder="{{'Repeat password'|translate}}"
-                    type="password"
-                    autocapitalize="off"
-                    ng-model="formData.repeatPassword"
-                    ng-change="checkPassword(formData.passphrase, formData.repeatPassword)"
-                    ng-class="{'correct': result == 'correct', 'incorrect': result == 'incorrect'}">
-          </div>
-
-          <div class="text-center box-notification error" ng-show="(formData.seedSource.id =='new' || formData.seedSource.id =='set') && encrypt">
-            <strong translate>This password cannot be recovered. If the password is lost, there is no way you could recover your funds.</strong>
-          </div>
-
-          <ion-checkbox ng-model="formData.passwordSaved" class="checkbox-positive" ng-show="encrypt && result == 'correct'">
-            <span class="toggle-label" translate>I have written it down</span>
-          </ion-checkbox>
 
           <label class="item item-input item-stacked-label" ng-show="formData.seedSource.id == 'set'">
             <span class="input-label" translate>Derivation Path</span>
-            <input type="text"
-                   placeholder="{{'BIP32 path for address derivation'|translate}}"
-                   name="derivationPath"
-                   ng-model="formData.derivationPath">
+            <input type="text" placeholder="{{'BIP32 path for address derivation'|translate}}" name="derivationPath" ng-model="formData.derivationPath">
           </label>
 
-        </div> <!-- advanced -->
-      </div> <!-- list -->
+        </div>
+        <!-- advanced -->
+      </div>
+      <!-- list -->
 
-      <button type="submit" class="button button-standard button-primary"
-        ng-disabled="setupForm.$invalid || ((encrypt && !formData.passwordSaved) || encrypt && ((formData.seedSource.id == 'new' && !formData.createPassphrase) || (formData.seedSource.id == 'set' && !formData.passphrase)))"
-        translate>Join
+      <button type="submit" class="button button-standard button-primary" ng-disabled="setupForm.$invalid" translate>Join
       </button>
     </form>
   </ion-content>

--- a/www/views/modals/password-warning.html
+++ b/www/views/modals/password-warning.html
@@ -1,0 +1,12 @@
+<div id="password-warning-modal" class="popup-modal">
+  <div class="popup-modal-header popup-modal-header-warning">
+    <div class="popup-modal-header-img-warning-2 popup-modal-header-img"></div>
+  </div>
+  <div class="popup-modal-content popup-modal-content-warning">
+    <div class="popup-modal-heading" translate>Are you sure?</div>
+    <div class="popup-modal-message" translate>Your wallet keys will be stored in plan text in this device, if an other app access the store it will be able to access
+      your Bitcoin</div>
+    <button class="button button-clear" ng-click="close()" translate>Yes</button>
+    <button class="button button-clear" ng-click="encrypt()" translate>No</button>
+  </div>
+</div>

--- a/www/views/modals/password-warning.html
+++ b/www/views/modals/password-warning.html
@@ -4,8 +4,7 @@
   </div>
   <div class="popup-modal-content popup-modal-content-warning">
     <div class="popup-modal-heading" translate>Are you sure?</div>
-    <div class="popup-modal-message" translate>Your wallet keys will be stored in plan text in this device, if an other app access the store it will be able to access
-      your Bitcoin</div>
+    <div class="popup-modal-message" translate>Your wallet keys will be stored in plain text and you will be vulnerable to having you coins stolen. We highly recommend pressing no and choosing a password.</div>
     <button class="button button-clear" ng-click="close()" translate>Yes</button>
     <button class="button button-clear" ng-click="encrypt()" translate>No</button>
   </div>

--- a/www/views/preferences.html
+++ b/www/views/preferences.html
@@ -44,7 +44,7 @@
       </a>
       <div ng-show="wallet.canSign()">
         <ion-toggle ng-model="encryptEnabled.value" toggle-class="toggle-balanced" ng-change="encryptChange()" ng-disabled="wallet.needsBackup">
-          <span ng-class="{'disabled': wallet.needsBackup}" class="toggle-label" translate>Request Spending Password</span>
+          <span ng-class="{'disabled': wallet.needsBackup}" class="toggle-label" translate>Set Spending Password</span>
         </ion-toggle>
         <div class="comment">
           <span translate>

--- a/www/views/tab-create-personal.html
+++ b/www/views/tab-create-personal.html
@@ -10,13 +10,8 @@
       <div class="list settings-list settings-input-group">
         <label class="item item-input item-stacked-label">
           <span class="input-label" translate>Wallet name</span>
-          <input type="text"
-          placeholder="{{'Family vacation funds'|translate}}"
-          ng-model="formData.walletName"
-          ng-required="true"
-          ng-focus="formFocus('wallet-name')"
-          ng-blur="formFocus(false)"
-          required>
+          <input type="text" placeholder="{{'Family vacation funds'|translate}}" ng-model="formData.walletName" ng-required="true"
+            ng-focus="formFocus('wallet-name')" ng-blur="formFocus(false)" required>
         </label>
 
         <div class="item item-divider"></div>
@@ -46,70 +41,12 @@
 
           <label class="item item-input item-stacked-label" ng-show="formData.seedSource.id == 'set'">
             <span class="input-label" translate>Wallet Recovery Phrase</span>
-            <input placeholder="{{'Enter the recovery phrase (BIP39)'|translate}}"
-            autocapitalize="off"
-            type="text"
-            ng-model="formData.privateKey">
+            <input placeholder="{{'Enter the recovery phrase (BIP39)'|translate}}" autocapitalize="off" type="text" ng-model="formData.privateKey">
           </label>
-
-          <div ng-show="formData.seedSource.id == 'new' || formData.seedSource.id == 'set'">
-            <ion-toggle class="has-comment" ng-model="encrypt" toggle-class="toggle-positive" ng-change="resizeView()">
-              <span class="toggle-label" translate>Add a password</span>
-            </ion-toggle>
-            <div class="comment">
-              <span ng-show="formData.seedSource.id == 'new'" translate>Add an optional password to secure the recovery phrase</span>
-              <span ng-show="formData.seedSource.id == 'set'" translate>The recovery phrase could require a password to be imported</span>
-            </div>
-          </div>
-
-          <div class="item item-input" ng-show="encrypt">
-            <input ng-show="formData.seedSource.id == 'new'"
-                   placeholder="{{'Password'|translate}}"
-                   type="password"
-                   autocapitalize="off"
-                   ng-model="formData.createPassphrase"
-                   ng-change="checkPassword(formData.createPassphrase, formData.repeatPassword)"
-                   ng-class="{'correct': result == 'correct', 'incorrect': result == 'incorrect'}">
-
-            <input ng-show="formData.seedSource.id == 'set'"
-                   placeholder="{{'Password'|translate}}"
-                   type="password"
-                   autocapitalize="off"
-                   ng-model="formData.passphrase"
-                   ng-change="checkPassword(formData.passphrase, formData.repeatPassword)"
-                   ng-class="{'correct': result == 'correct', 'incorrect': result == 'incorrect'}">
-          </div>
-          <div class="item item-input" ng-show="encrypt">
-            <input ng-show="formData.seedSource.id == 'new'"
-                   placeholder="{{'Repeat password'|translate}}"
-                   type="password"
-                   autocapitalize="off"
-                   ng-model="formData.repeatPassword"
-                   ng-change="checkPassword(formData.createPassphrase, formData.repeatPassword)"
-                   ng-class="{'correct': result == 'correct', 'incorrect': result == 'incorrect'}">
-
-             <input ng-show="formData.seedSource.id == 'set'"
-                    placeholder="{{'Repeat password'|translate}}"
-                    type="password"
-                    autocapitalize="off"
-                    ng-model="formData.repeatPassword"
-                    ng-change="checkPassword(formData.passphrase, formData.repeatPassword)"
-                    ng-class="{'correct': result == 'correct', 'incorrect': result == 'incorrect'}">
-          </div>
-
-          <div class="text-center box-notification error" ng-show="(formData.seedSource.id =='new' || formData.seedSource.id =='set') && encrypt">
-            <strong translate>This password cannot be recovered. If the password is lost, there is no way you could recover your funds.</strong>
-          </div>
-
-          <ion-checkbox ng-model="formData.passwordSaved" class="checkbox-positive" ng-show="encrypt && result == 'correct'">
-            <span class="toggle-label" translate>I have written it down</span>
-          </ion-checkbox>
 
           <label class="item item-input item-stacked-label" ng-show="formData.seedSource.id == 'set'">
             <span class="input-label" translate>Derivation Path</span>
-            <input type="text"
-            placeholder="{{'BIP32 path for address derivation'|translate}}"
-            ng-model="formData.derivationPath">
+            <input type="text" placeholder="{{'BIP32 path for address derivation'|translate}}" ng-model="formData.derivationPath">
           </label>
 
           <ion-toggle ng-show="formData.seedSource.supportsTestnet" ng-model="formData.testnetEnabled" toggle-class="toggle-positive">
@@ -121,11 +58,12 @@
             <small translate>For audit purposes</small>
           </ion-toggle>
 
-        </div> <!-- advanced -->
-      </div> <!-- list -->
+        </div>
+        <!-- advanced -->
+      </div>
+      <!-- list -->
 
-      <button type="submit" class="button button-standard button-primary"
-        ng-disabled="setupForm.$invalid || ((encrypt && !formData.passwordSaved) || encrypt && ((formData.seedSource.id == 'new' && !formData.createPassphrase) || (formData.seedSource.id == 'set' && !formData.passphrase)))">
+      <button type="submit" class="button button-standard button-primary" ng-disabled="setupForm.$invalid">
         <span translate>Create new wallet</span>
       </button>
     </form>

--- a/www/views/tab-create-shared.html
+++ b/www/views/tab-create-shared.html
@@ -10,23 +10,14 @@
       <div class="list settings-list settings-input-group">
         <label class="item item-input item-stacked-label">
           <span class="input-label" translate>Wallet name</span>
-          <input type="text"
-            placeholder="{{'Family vacation funds'|translate}}"
-            ng-model="formData.walletName"
-            ng-required="true"
-            ng-focus="formFocus('wallet-name')"
-            ng-blur="formFocus(false)">
+          <input type="text" placeholder="{{'Family vacation funds'|translate}}" ng-model="formData.walletName" ng-required="true"
+            ng-focus="formFocus('wallet-name')" ng-blur="formFocus(false)">
         </label>
 
         <label class="item item-input item-stacked-label">
           <span class="input-label" translate>Your name</span>
-          <input type="text"
-            placeholder="Satoshi"
-            ng-model="formData.myName"
-            ng-required="formData.totalCopayers != 1"
-            ng-disabled="formData.totalCopayers == 1"
-            ng-focus="formFocus('my-name')"
-            ng-blur="formFocus(false)">
+          <input type="text" placeholder="Satoshi" ng-model="formData.myName" ng-required="formData.totalCopayers != 1" ng-disabled="formData.totalCopayers == 1"
+            ng-focus="formFocus('my-name')" ng-blur="formFocus(false)">
         </label>
 
         <label class="item item-input item-select">
@@ -42,8 +33,7 @@
           <div class="input-label" translate>
             Required number of signatures
           </div>
-          <select class="m10t"
-            ng-model="formData.requiredCopayers" ng-options="requiredCopayers as requiredCopayers for requiredCopayers in RCValues"
+          <select class="m10t" ng-model="formData.requiredCopayers" ng-options="requiredCopayers as requiredCopayers for requiredCopayers in RCValues"
             ng-disabled="formData.totalCopayers == 1">
           </select>
         </label>
@@ -75,70 +65,12 @@
 
           <label class="item item-input item-stacked-label" ng-show="formData.seedSource.id == 'set'">
             <span class="input-label" translate>Wallet Recovery Phrase</span>
-            <input placeholder="{{'Enter the recovery phrase (BIP39)'|translate}}"
-            autocapitalize="off"
-            type="text"
-            ng-model="formData.privateKey">
+            <input placeholder="{{'Enter the recovery phrase (BIP39)'|translate}}" autocapitalize="off" type="text" ng-model="formData.privateKey">
           </label>
-
-          <div ng-show="formData.seedSource.id == 'new' || formData.seedSource.id == 'set'">
-            <ion-toggle class="has-comment" ng-model="encrypt" toggle-class="toggle-positive" ng-change="resizeView()">
-              <span class="toggle-label" translate>Add a password</span>
-            </ion-toggle>
-            <div class="comment">
-              <span ng-show="formData.seedSource.id == 'new'" translate>Add an optional password to secure the recovery phrase</span>
-              <span ng-show="formData.seedSource.id == 'set'" translate>The recovery phrase could require a password to be imported</span>
-            </div>
-          </div>
-
-          <div class="item item-input" ng-show="encrypt">
-            <input ng-show="formData.seedSource.id == 'new'"
-                   placeholder="{{'Password'|translate}}"
-                   type="password"
-                   autocapitalize="off"
-                   ng-model="formData.createPassphrase"
-                   ng-change="checkPassword(formData.createPassphrase, formData.repeatPassword)"
-                   ng-class="{'correct': result == 'correct', 'incorrect': result == 'incorrect'}">
-
-            <input ng-show="formData.seedSource.id == 'set'"
-                   placeholder="{{'Password'|translate}}"
-                   type="password"
-                   autocapitalize="off"
-                   ng-model="formData.passphrase"
-                   ng-change="checkPassword(formData.passphrase, formData.repeatPassword)"
-                   ng-class="{'correct': result == 'correct', 'incorrect': result == 'incorrect'}">
-          </div>
-          <div class="item item-input" ng-show="encrypt">
-            <input ng-show="formData.seedSource.id == 'new'"
-                   placeholder="{{'Repeat password'|translate}}"
-                   type="password"
-                   autocapitalize="off"
-                   ng-model="formData.repeatPassword"
-                   ng-change="checkPassword(formData.createPassphrase, formData.repeatPassword)"
-                   ng-class="{'correct': result == 'correct', 'incorrect': result == 'incorrect'}">
-
-             <input ng-show="formData.seedSource.id == 'set'"
-                    placeholder="{{'Repeat password'|translate}}"
-                    type="password"
-                    autocapitalize="off"
-                    ng-model="formData.repeatPassword"
-                    ng-change="checkPassword(formData.passphrase, formData.repeatPassword)"
-                    ng-class="{'correct': result == 'correct', 'incorrect': result == 'incorrect'}">
-          </div>
-
-          <div class="text-center box-notification error" ng-show="(formData.seedSource.id =='new' || formData.seedSource.id =='set') && encrypt">
-            <strong translate>This password cannot be recovered. If the password is lost, there is no way you could recover your funds.</strong>
-          </div>
-
-          <ion-checkbox ng-model="formData.passwordSaved" class="checkbox-positive" ng-show="encrypt && result == 'correct'">
-            <span class="toggle-label" translate>I have written it down</span>
-          </ion-checkbox>
 
           <label class="item item-input item-stacked-label" ng-show="formData.seedSource.id  == 'set'">
             <span class="input-label" translate>Derivation Path</span>
-            <input type="text"
-            placeholder="{{'BIP32 path for address derivation'|translate}}"
-            ng-model="formData.derivationPath">
+            <input type="text" placeholder="{{'BIP32 path for address derivation'|translate}}" ng-model="formData.derivationPath">
           </label>
 
           <ion-toggle ng-show="formData.seedSource.supportsTestnet" ng-model="formData.testnetEnabled" toggle-class="toggle-positive">
@@ -150,11 +82,12 @@
             <small translate>For audit purposes</small>
           </ion-toggle>
 
-        </div> <!-- advanced -->
-      </div> <!-- list -->
+        </div>
+        <!-- advanced -->
+      </div>
+      <!-- list -->
 
-      <button type="submit" class="button button-standard button-primary"
-        ng-disabled="setupForm.$invalid || ((encrypt && !formData.passwordSaved) || encrypt && ((formData.seedSource.id == 'new' && !formData.createPassphrase) || (formData.seedSource.id == 'set' && !formData.passphrase)))">
+      <button type="submit" class="button button-standard button-primary" ng-disabled="setupForm.$invalid">
         <span translate>Create {{formData.requiredCopayers}}-of-{{formData.totalCopayers}} wallet</span>
       </button>
     </form>

--- a/www/views/tab-home.html
+++ b/www/views/tab-home.html
@@ -113,7 +113,12 @@
             <i ng-if="!wallet.balanceHidden && (wallet.status.totalBalanceSat != wallet.status.spendableAmount)" class="tab-home__wallet__status-icon ion-ios-timer-outline"></i>
             <span class="assertive" ng-if="wallet.error">{{wallet.error}}</span>
           </span>
-          &nbsp;
+          <span class="right text-light assertive" ng-show="wallet.isComplete() && wallet.needsBackup">
+            {{'Backup required' | translate}} &nbsp; &nbsp;
+          </span>
+          <span class="right text-light assertive" ng-show="wallet.isComplete() && wallet.needsEncryption">
+            {{'Encryption required' | translate}} &nbsp; &nbsp;
+          </span>
           </p>
           <i class="icon bp-arrow-right"></i>
         </a>

--- a/www/views/tab-settings.html
+++ b/www/views/tab-settings.html
@@ -133,6 +133,9 @@
         <span class="right text-light assertive" ng-show="item.isComplete() && item.needsBackup">
           {{'Backup needed' | translate}}
         </span>
+        <span class="right text-light assertive" ng-show="item.isComplete() && item.needsEncryption">
+            {{'Encryption required' | translate}} &nbsp; &nbsp;
+          </span>
         <i class="icon bp-arrow-right"></i>
       </a>
 

--- a/www/views/walletDetails.html
+++ b/www/views/walletDetails.html
@@ -154,12 +154,16 @@
       </div>
     </div> <!-- oh -->
 
-    <a class="wallet-not-backed-up-warning" ng-if="wallet.needsBackup" ui-sref="tabs.wallet.backupWarning({from: 'tabs.wallet'})" translate>
+    <a class="wallet-not-backed-up-warning" ng-if="wallet.needsBackup" ui-sref="tabs.wallet.backupWarning({walletId: wallet.id, from: 'tabs.wallet'})" translate>
       Wallet not backed up
     </a>
 
+    <span class="wallet-not-backed-up-warning" ng-if="wallet.needsEncryption" translate>
+      Wallet not encrypted. Set spending password to encrypt.
+    </span>
 
-    <a class="wallet-not-backed-up-warning" ng-if="lowUtxosWarning" ui-sref="tabs.wallet.addresses({walletId:wallet.id,from: 'tabs.wallet'})" translate>
+
+    <a class="wallet-not-backed-up-warning" ng-if="lowUtxosWarning" ui-sref="tabs.wallet.addresses({walletId:wallet.id, from: 'tabs.wallet'})" translate>
       Spending this balance will need significant NavCoin network fees
     </a>
 


### PR DESCRIPTION
Adds additional step when setting up wallet to create 'spending' / 'encryption' password.

- [ ] Add password when creating first wallet
- [ ] Add password when creating additional wallets
- [ ] Handle cancels with warnings
- [ ] Show user the wallet is unencrypted on home page
- [ ] Show user the wallet is unencrypted on wallet page
- [ ] Add ability to copy seed phrase to clipboard from backup page
- [ ] Add ability to generate QR code on backup page

## Testing
Web testing: https://navpay-additional-setup.now.sh
Android: https://s3-ap-southeast-2.amazonaws.com/random-navcore-dev-stuff/navpay-additional-setup.apk
Build: Git clone, npm install, npm start.

- [ ] Create new brand new wallet with password
- [ ] Create brand new wallet without password
- [ ] Create additional wallet with password
- [ ] Create additional wallet without password
- [ ] Confirm that is notification on unencrypted wallets
- [ ] Confirm seed phrase can be copied to clipboard from backup screen
- [ ] Confirm QR code is generated on backup screen and can be used to seed wallet elsewhere.