### PR TITLE
QR improvements

### DIFF
--- a/src/js/controllers/tab-scan.js
+++ b/src/js/controllers/tab-scan.js
@@ -208,11 +208,10 @@ angular.module('copayApp.controllers').controller('tabScanController', function(
     scannerService.pausePreview();
     if ($scope.usingWebRtc) { stopWebRtcCamera() }
 
-    var trimmedContents = contents.replace('navcoin:', '');
     if ($scope.returnRoute) {
-      $state.go($scope.returnRoute, { address: trimmedContents });
+      $state.go($scope.returnRoute, { address: contents });
     } else {
-      incomingData.redir(trimmedContents);
+      incomingData.redir(contents);
     }
   }
 
@@ -273,14 +272,13 @@ angular.module('copayApp.controllers').controller('tabScanController', function(
       ctx.drawImage(video, 0, 0, width, height);
 
       // Get the image data, and run it through jsQR
-      var imageData = ctx.getImageData(0, 0, width, height);
+      var imageData = ctx.getImageData(0, 0, width, height)
       var scanResults = jsQR(imageData.data, width, height)
 
-      $log.debug('QR Code', scanResults)
-      if (scanResults && scanResults.data.includes('navcoin')) {
+      if (scanResults && scanResults.data) {
+        $log.debug('QR Code', scanResults)
         handleSuccessfulScan(scanResults.data);
       }
-
     })
   }
 
@@ -318,7 +316,7 @@ angular.module('copayApp.controllers').controller('tabScanController', function(
         var scanResults = jsQR(imageData.data, image.width, image.height)
 
         $log.debug('QR Code', scanResults)
-        if (scanResults && scanResults.data.includes('navcoin')) {
+        if (scanResults) {
           handleSuccessfulScan(scanResults.data);
         } else {
           // Ask user to try again

--- a/src/js/services/incomingData.js
+++ b/src/js/services/incomingData.js
@@ -10,8 +10,15 @@ angular.module('copayApp.services').factory('incomingData', function($log, $stat
 
   root.redir = function(data, privatePayment, stopRedirect) {
     $log.debug('Processing incoming data: ' + data);
+    function sanitizeData(data) {
+      data = data.replace('navcoin:', 'bitcoin:')
 
-    function sanitizeUri(data) {
+      // When we get a QR code, add bitcoin in front and see if it makes a valid address
+      var testBitcoinAddress = 'bitcoin:' + data
+      if (bitcore.URI.isValid(testBitcoinAddress)) {
+        data: 'bitcoin:' + data
+      }
+
       // Fixes when a region uses comma to separate decimals
       var regex = /[\?\&]amount=(\d+([\,\.]\d+)?)/i;
       var match = regex.exec(data);
@@ -81,7 +88,7 @@ angular.module('copayApp.services').factory('incomingData', function($log, $stat
       return true;
     }
 
-    data = sanitizeUri(data);
+    data = sanitizeData(data);
 
     // BIP21
     if (bitcore.URI.isValid(data)) {


### PR DESCRIPTION
## Changes
**Issue 1**
Currently when the app scans the 'receive amount' QR code is doesn't handle the amount correctly.
Currently affecting the web + pwa versions.

**Issue 2**
Current some exchanges dont include the `navcoin:` at start of QR code. We should try handle this by warning that  we are unable to confirm it is a navcoin address, are they sure they want to send to this address.

**Issue 3**
Backup QR code not working on web version

- [x] Fix receive amount QR code
- [x] Add ability to handle addresses that dont start with 'navcoin:' 
- [x] Backup QR code not working correctly

## Testing
iOS / Web.
Update iOS PWA app by deleting and re-download from navpay-beta.navcoin.org
- [ ] Create QR code to receive 5 navcoin. Scan QR code
- [ ] Use a QR code generator and try scan just an address
- [ ] Goto wallet -> backup. Click Show QR. Scan QR with iOS app and check wallet is imported.